### PR TITLE
fix(aws-cdk): fix nx linter

### DIFF
--- a/packages/nx-aws-cdk/README.md
+++ b/packages/nx-aws-cdk/README.md
@@ -28,7 +28,7 @@ An Nx plugin for developing [aws-cdk](https://docs.aws.amazon.com/cdk/latest/gui
 npm install --save-dev @codebrew/nx-aws-cdk
 
 # yarn
-yarn add --save-dev @codebrew/nx-aws-cdk
+yarn add --dev @codebrew/nx-aws-cdk
 ```
 
 ## Usage

--- a/packages/nx-aws-cdk/src/generators/application/application.ts
+++ b/packages/nx-aws-cdk/src/generators/application/application.ts
@@ -73,7 +73,7 @@ async function addLintingToApplication(tree: Tree, options: NormalizedSchema): P
     linter: options.linter,
     project: options.projectName,
     tsConfigPaths: [joinPathFragments(options.projectRoot, 'tsconfig.*?.json')],
-    eslintFilePatterns: [`${options.projectRoot}/**/*.ts}`],
+    eslintFilePatterns: [`${options.projectRoot}/**/*.ts`],
     skipFormat: true,
     setParserOptionsProject: options.setParserOptionsProject,
   });


### PR DESCRIPTION
# Description

# PR Checklist

- [ y] Migrations have been added if necessary
- [y ] Unit tests have been added or updated if necessary
- [ y] e2e tests have been added or updated if necessary
- [ n] Changelog has been updated if necessary
- [ y] Documentation has been updated if necessary

# Issue
NX linter was not working.  Once a new project was created the 'nx lint projectName' command was returning an error.

Also, updated a small syntax update to the yarn add command in the readme so that it's valid and works properly for yarn users.

Resolves #
NX lint now works for new projects created by plugin
