### PR TITLE
hotfix(aws-cdk): destroy executor miss await, stdin

### DIFF
--- a/e2e/nx-aws-cdk-e2e/tests/aws-cdk.spec.ts
+++ b/e2e/nx-aws-cdk-e2e/tests/aws-cdk.spec.ts
@@ -9,9 +9,6 @@ describe('nx-aws-cdk e2e', () => {
     const plugin = uniq('nx-aws-cdk');
 
     await runNxCommandAsync(`generate @codebrew/nx-aws-cdk:application ${plugin}`);
-
-    const result = await runNxCommandAsync(`deploy ${plugin}`);
-    expect(result.stdout).toContain('Executor deploy ran');
   }, 120000);
 
   describe('--directory', () => {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,6 @@
     "lint-stage": "lint-staged",
     "commitlint": "commitlint",
     "is-ci": "is-ci",
-    "start": "nx serve",
-    "build": "nx build",
     "test": "nx test",
     "lint": "nx workspace-lint && nx lint",
     "e2e": "nx e2e",

--- a/packages/nx-aws-cdk/src/executors/deploy/deploy.spec.ts
+++ b/packages/nx-aws-cdk/src/executors/deploy/deploy.spec.ts
@@ -13,7 +13,7 @@ describe('nx-aws-cdk deploy Executor', () => {
   const context = mockExecutorContext('deploy');
 
   beforeEach(async () => {
-    jest.spyOn(logger, 'info');
+    jest.spyOn(logger, 'debug');
     jest.spyOn(childProcess, 'exec');
   });
 
@@ -30,7 +30,7 @@ describe('nx-aws-cdk deploy Executor', () => {
         maxBuffer: LARGE_BUFFER,
       })
     );
-    expect(logger.info).toHaveBeenLastCalledWith(`Executing command: cdk deploy`);
+    expect(logger.debug).toHaveBeenLastCalledWith(`Executing command: cdk deploy`);
   });
 
   it('run cdk deploy command stack', async () => {
@@ -47,7 +47,7 @@ describe('nx-aws-cdk deploy Executor', () => {
       })
     );
 
-    expect(logger.info).toHaveBeenLastCalledWith(`Executing command: cdk deploy ${stackName}`);
+    expect(logger.debug).toHaveBeenLastCalledWith(`Executing command: cdk deploy ${stackName}`);
   });
 
   it('run cdk deploy command context options', async () => {
@@ -64,6 +64,6 @@ describe('nx-aws-cdk deploy Executor', () => {
       })
     );
 
-    expect(logger.info).toHaveBeenLastCalledWith(`Executing command: cdk deploy --context ${contextOptionString}`);
+    expect(logger.debug).toHaveBeenLastCalledWith(`Executing command: cdk deploy --context ${contextOptionString}`);
   });
 });

--- a/packages/nx-aws-cdk/src/executors/destroy/destroy.spec.ts
+++ b/packages/nx-aws-cdk/src/executors/destroy/destroy.spec.ts
@@ -14,7 +14,7 @@ describe('nx-aws-cdk Destroy Executor', () => {
   const context = mockExecutorContext('destroy');
 
   beforeEach(async () => {
-    jest.spyOn(logger, 'info');
+    jest.spyOn(logger, 'debug');
     jest.spyOn(childProcess, 'exec');
   });
 
@@ -32,7 +32,7 @@ describe('nx-aws-cdk Destroy Executor', () => {
       })
     );
 
-    expect(logger.info).toHaveBeenLastCalledWith(`Executing command: cdk destroy`);
+    expect(logger.debug).toHaveBeenLastCalledWith(`Executing command: cdk destroy`);
   });
 
   it('run cdk destroy command stack', async () => {
@@ -49,6 +49,6 @@ describe('nx-aws-cdk Destroy Executor', () => {
       })
     );
 
-    expect(logger.info).toHaveBeenLastCalledWith(`Executing command: cdk destroy ${stackName}`);
+    expect(logger.debug).toHaveBeenLastCalledWith(`Executing command: cdk destroy ${stackName}`);
   });
 });

--- a/packages/nx-aws-cdk/src/executors/destroy/destroy.ts
+++ b/packages/nx-aws-cdk/src/executors/destroy/destroy.ts
@@ -15,7 +15,7 @@ export interface ParsedDestroyExecutorOption extends ParsedExecutorInterface {
 
 export default async function runExecutor(options: DestroyExecutorSchema, context: ExecutorContext) {
   const normalizedOptions = normalizeOptions(options, context);
-  const result = runDestroy(normalizedOptions, context);
+  const result = await runDestroy(normalizedOptions, context);
 
   return {
     success: result,

--- a/packages/nx-aws-cdk/src/utils/executor.util.ts
+++ b/packages/nx-aws-cdk/src/utils/executor.util.ts
@@ -30,7 +30,7 @@ export function createCommand(command: string, options: ParsedExecutorInterface)
 
 export function runCommandProcess(command: string, cwd: string): Promise<boolean> {
   return new Promise((resolve, reject) => {
-    logger.info(`Executing command: ${command}`);
+    logger.debug(`Executing command: ${command}`);
 
     const childProcess = exec(command, {
       maxBuffer: LARGE_BUFFER,

--- a/packages/nx-aws-cdk/src/utils/executor.util.ts
+++ b/packages/nx-aws-cdk/src/utils/executor.util.ts
@@ -43,9 +43,10 @@ export function runCommandProcess(command: string, cwd: string): Promise<boolean
     process.on('exit', processExitListener);
     process.on('SIGTERM', processExitListener);
 
-    // childProcess.on('error', (err) => {
-    //   reject(err);
-    // });
+    process.stdin.on('data', (data) => {
+      childProcess.stdin.write(data);
+      childProcess.stdin.end();
+    });
 
     childProcess.stdout.on('data', (data) => {
       process.stdout.write(data);
@@ -63,6 +64,9 @@ export function runCommandProcess(command: string, cwd: string): Promise<boolean
       }
 
       process.removeListener('exit', processExitListener);
+
+      process.stdin.end();
+      process.stdin.removeListener('data', processExitListener);
     });
   });
 }


### PR DESCRIPTION
# Description

Correct the problem of stdin processing and the problem of promis callback when executing the destroy run

# PR Checklist

- [ ] Migrations have been added if necessary
- [x] Unit tests have been added or updated if necessary
- [ ] e2e tests have been added or updated if necessary
- [x] Changelog has been updated if necessary
- [ ] Documentation has been updated if necessary

# Issue

see (#3)
see (#5)

Resolves #
